### PR TITLE
Fix SHA256 mismatch

### DIFF
--- a/cn.rb
+++ b/cn.rb
@@ -2,7 +2,7 @@ class Cn < Formula
   desc "CLI for CommonNumerics routines (CRC-8/16/32/64, Base16/32/64)"
   homepage "https://github.com/JayBrown/cn"
   url "https://github.com/JayBrown/cn/archive/1.00.tar.gz"
-  sha256 "4a11ccf8ba82f344f4d8faffc9a3cc28c5971d00f8e0f85d2682bb70e351e660"
+  sha256 "ac0472649f09d20f396767e1f9fa185a59639bd17fc32153f5dd4a2135dbebc9"
 
   def install
     system "make prefix=#{prefix}"


### PR DESCRIPTION
This PR fixes the following SHA mismatch:

```
± brew install jaybrown/cn/cn
==> Installing cn from jaybrown/cn
==> Downloading https://github.com/JayBrown/cn/archive/1.00.tar.gz
==> Downloading from https://codeload.github.com/JayBrown/cn/tar.gz/1.00
######################################################################## 100,0%
Error: SHA256 mismatch
Expected: 4a11ccf8ba82f344f4d8faffc9a3cc28c5971d00f8e0f85d2682bb70e351e660
Actual: ac0472649f09d20f396767e1f9fa185a59639bd17fc32153f5dd4a2135dbebc9
```

The actual SHA256 of the v1.00 release tarball is:

> ac0472649f09d20f396767e1f9fa185a59639bd17fc32153f5dd4a2135dbebc9

I found it a bit difficult to audit that mismatch because the tarball currently appears to have no matching commit on `master`. For example, it differs from commit 2e9166fa3996d3f71fefda252cf453c9d2f8c7cd as follows:

```
5c5
< You can **[install cn](https://github.com/JayBrown/cn-tap)** with **[Homebrew](https://brew.sh)** (recommended), or you can **manually make/build** with `make clean` and `make cn`.
---
> You can install **cn** using **[Homebrew](https://brew.sh)** (recommended) with `brew tap JayBrown/cn && brew install cn` ([tap repo with formula](https://github.com/JayBrown/homebrew-cn)), or you can **manually make/build** with `make clean` and `make cn`.
```

(This information doesn’t really explain the SHA256 mismatch on the tarball. It’s just to document how the v1.00 tarball can be reproduced.)
